### PR TITLE
improve rendering on zoom out of traces

### DIFF
--- a/src/can2/pd.py
+++ b/src/can2/pd.py
@@ -17,6 +17,7 @@
 ## along with this program; if not, see <http://www.gnu.org/licenses/>.
 ##
 import struct
+import string
 from collections import OrderedDict, namedtuple
 import sigrokdecode as srd
 
@@ -696,6 +697,7 @@ class Decoder(srd.Decoder):
         self.sample_period_ns = None  # type: float
         self.out_ann = None
         self.out_binary = None
+        self.printables = set(string.printable)
 
     def metadata(self, key, value):
         if key == srd.SRD_CONF_SAMPLERATE:
@@ -810,7 +812,7 @@ class Decoder(srd.Decoder):
         for i in range(len(CANField.data_bytes)):
             databyte = CANField.data_bytes[i]
             b = databyte.get_value()
-            if self.display_ascii:
+            if self.display_ascii and chr(b) in self.printables:
                 a = str(bytes([b]))[1:]
                 data = [Annotation.lookup('can-payload'), ["DATA{}=0x{:02x} {}".format(i, b, a),
                                                            "0x{:02x} {}".format(b, a),
@@ -827,7 +829,7 @@ class Decoder(srd.Decoder):
         for i in range(len(CANField.data_bytes)):
             bs.append(CANField.data_bytes[i].get_value())
         if self.display_ascii:
-            cs = str(bytes(bs))[1:]
+            cs = "'" + ''.join(chr(i) if chr(i) in self.printables else '.' for i in bs) + "'"
             bs = bytes(bs).hex()
             data = [Annotation.lookup('data'), ["DATA=0x{} {}".format(bs, cs),
                                                 "0x{} {}".format(bs, cs),

--- a/src/can2/pd.py
+++ b/src/can2/pd.py
@@ -661,7 +661,7 @@ class Decoder(srd.Decoder):
     annotations = Annotation.get_annotations()
     annotation_rows = (
         ('row-bits', "Bits", Annotation.get_annotation_row(['bit', 'stuffbit'])),
-        ('row-can-fields', "Fields", Annotation.get_annotation_row(['data',
+        ('row-can-fields', "Fields", Annotation.get_annotation_row(['can-payload',
                                                                     'sof',
                                                                     'eof',
                                                                     'ida',
@@ -682,7 +682,7 @@ class Decoder(srd.Decoder):
                                                                     'error-delimiter',
                                                                     'ifs',
                                                                     'idle'])),
-        ('row-can-payload', "Payload", Annotation.get_annotation_row(['can-id', 'can-payload'])),
+        ('row-can-payload', "Payload", Annotation.get_annotation_row(['can-id', 'data'])),
         ('row-can-warning', "Info", Annotation.get_annotation_row(['can-warning', 'can-info'])),
     )
 

--- a/src/can2/pd.py
+++ b/src/can2/pd.py
@@ -829,6 +829,8 @@ class Decoder(srd.Decoder):
             can_id_strs = ["ID=0x{:08x} (Extended)".format(can_id),
                            "ID=0x{:08x} (Ext)".format(can_id),
                            "ID=0x{:08x}E".format(can_id),
+                           "ID={:08x}".format(can_id),
+                           "{:08x}".format(can_id),
                            "ID(Ext)",
                            "ID",
                            ""]
@@ -838,6 +840,8 @@ class Decoder(srd.Decoder):
             can_id_strs = ["ID=0x{:03x} (Standard)".format(can_id),
                            "ID=0x{:03x} (Std)".format(can_id),
                            "ID=0x{:03x}".format(can_id),
+                           "ID={:03x}".format(can_id),
+                           "{:03x}".format(can_id),
                            "ID(Std)",
                            "ID(S)",
                            "ID",

--- a/src/can2/pd.py
+++ b/src/can2/pd.py
@@ -815,6 +815,7 @@ class Decoder(srd.Decoder):
             else:
                 data = [Annotation.lookup('can-payload'), ["DATA{}=0x{:02x}".format(i, b),
                                                            "0x{:02x}".format(b),
+                                                           "{:02x}".format(b),
                                                            ""]]
             self.put(databyte.canbits[0].start_samplenum, databyte.canbits[-1].end_samplenum, self.out_ann, data)
 


### PR DESCRIPTION
This PR is proposing a few things to make zoom out on the traces fit more decodes -- each is logically separated into its own commit.
* provide more format options to sigrok for shorter decodes of ID and Data (e.g. strip '0x')
* provide the string of payload bytes in the longer 'data' / 'Payload' annotation
* swap the row for the 'data' / 'Payload' annotation so it is in the 'Payload' row. rationale: it is a long annotation which spans multiple 'fields' so fits better in that row. As a bonus the user can hide the bits and fields rows and just look at the equivalent of a candump log output format on the traces
* skip python byte escaping for the ascii half of the decoded format when the hex+ascii option is selected and either skip indv characters or use the hexdump -C way of printing a `.`

---

before:
![image](https://user-images.githubusercontent.com/243321/125013009-19783c80-e039-11eb-89f3-bff29556f2c1.png)
after:
![image](https://user-images.githubusercontent.com/243321/125012969-09f8f380-e039-11eb-8429-d08482c38ff9.png)

---

before:
![image](https://user-images.githubusercontent.com/243321/125012831-d4eca100-e038-11eb-82bd-179db6ff1082.png)
after:
![image](https://user-images.githubusercontent.com/243321/125012781-bf777700-e038-11eb-8281-edebf0621f8d.png)
